### PR TITLE
Add bedrock protections and finish anti-illegal features

### DIFF
--- a/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
+++ b/src/main/java/com/blbilink/blbilogin/load/LoadFunction.java
@@ -4,6 +4,7 @@ import com.blbilink.blbilogin.BlbiLogin;
 import com.blbilink.blbilogin.modules.Sqlite;
 import com.blbilink.blbilogin.modules.commands.*;
 import com.blbilink.blbilogin.modules.events.PlayerJoin;
+import com.blbilink.blbilogin.modules.events.BlockProtection;
 import com.blbilink.blbilogin.modules.events.PlayerSendMessage;
 import com.blbilink.blbilogin.modules.events.PlayerUseCommands;
 import com.blbilink.blbilogin.modules.events.PlayerInteraction;
@@ -58,6 +59,7 @@ public class LoadFunction {
         Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.dupe.ChestBoatDupeListener(0), plugin);
         Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.events.SpamProtection(), plugin);
         Bukkit.getPluginManager().registerEvents(new com.blbilink.blbilogin.modules.events.WitherSkullExplodeFix(), plugin);
+        Bukkit.getPluginManager().registerEvents(new BlockProtection(), plugin);
     }
 
     private void loadSqlite(){

--- a/src/main/java/com/blbilink/blbilogin/modules/events/BlockProtection.java
+++ b/src/main/java/com/blbilink/blbilogin/modules/events/BlockProtection.java
@@ -1,0 +1,56 @@
+package com.blbilink.blbilogin.modules.events;
+
+import com.blbilink.blbilogin.vars.Configvar;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+public class BlockProtection implements Listener {
+    private final int radius = 5;
+    private final Location center;
+
+    public BlockProtection() {
+        String worldName = Configvar.config.getString("locationPos.world");
+        if (worldName != null && !worldName.isEmpty()) {
+            this.center = new Location(
+                    Bukkit.getWorld(worldName),
+                    Configvar.config.getDouble("locationPos.x"),
+                    Configvar.config.getDouble("locationPos.y"),
+                    Configvar.config.getDouble("locationPos.z")
+            );
+        } else {
+            this.center = null;
+        }
+    }
+
+    private boolean inProtectedZone(Location loc) {
+        if (center == null) return false;
+        if (loc.getWorld() == null || !loc.getWorld().equals(center.getWorld())) return false;
+        return Math.abs(loc.getX() - center.getX()) <= radius &&
+                Math.abs(loc.getY() - center.getY()) <= radius &&
+                Math.abs(loc.getZ() - center.getZ()) <= radius;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        Material type = event.getBlockPlaced().getType();
+        if (type == Material.BEDROCK || type == Material.BARRIER) {
+            event.setCancelled(true);
+            return;
+        }
+        if (!event.getPlayer().isOp() && inProtectedZone(event.getBlock().getLocation())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        if (!event.getPlayer().isOp() && inProtectedZone(event.getBlock().getLocation())) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/AttributeCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/AttributeCheck.java
@@ -1,14 +1,36 @@
 package me.txmc.core.antiillegal.check.checks;
 
+import com.google.common.collect.Multimap;
 import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
-/** Placeholder for AttributeCheck */
+/**
+ * Removes unsafe attribute modifiers from items.
+ */
 public class AttributeCheck implements Check {
     @Override
-    public boolean check(ItemStack item) { return false; }
+    public boolean check(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+        Multimap<Attribute, AttributeModifier> mods = meta.getAttributeModifiers();
+        return mods != null && !mods.isEmpty();
+    }
+
     @Override
-    public boolean shouldCheck(ItemStack item) { return false; }
+    public boolean shouldCheck(ItemStack item) {
+        return item != null && item.hasItemMeta();
+    }
+
     @Override
-    public void fix(ItemStack item) {}
+    public void fix(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        for (Attribute attr : Attribute.values()) {
+            meta.removeAttributeModifier(attr);
+        }
+        item.setItemMeta(meta);
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/BookCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/BookCheck.java
@@ -2,13 +2,46 @@ package me.txmc.core.antiillegal.check.checks;
 
 import me.txmc.core.antiillegal.check.Check;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
 
-/** Placeholder for BookCheck */
+import java.util.List;
+
+/**
+ * Sanitizes written books to reasonable limits.
+ */
 public class BookCheck implements Check {
+    private static final int MAX_PAGES = 50;
+    private static final int MAX_PAGE_LENGTH = 32000;
+
     @Override
-    public boolean check(ItemStack item) { return false; }
+    public boolean check(ItemStack item) {
+        if (!(item.getItemMeta() instanceof BookMeta meta)) return false;
+        if (meta.getPageCount() > MAX_PAGES) return true;
+        for (String page : meta.getPages()) {
+            if (page.length() > MAX_PAGE_LENGTH) return true;
+        }
+        return false;
+    }
+
     @Override
-    public boolean shouldCheck(ItemStack item) { return false; }
+    public boolean shouldCheck(ItemStack item) {
+        return item != null && item.getItemMeta() instanceof BookMeta;
+    }
+
     @Override
-    public void fix(ItemStack item) {}
+    public void fix(ItemStack item) {
+        if (!(item.getItemMeta() instanceof BookMeta meta)) return;
+        while (meta.getPageCount() > MAX_PAGES) {
+            meta.removePage(meta.getPageCount());
+        }
+        List<String> pages = meta.getPages();
+        for (int i = 0; i < pages.size(); i++) {
+            String text = pages.get(i);
+            if (text.length() > MAX_PAGE_LENGTH) {
+                pages.set(i, text.substring(0, MAX_PAGE_LENGTH));
+            }
+        }
+        meta.setPages(pages);
+        item.setItemMeta(meta);
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/DurabilityCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/DurabilityCheck.java
@@ -2,13 +2,31 @@ package me.txmc.core.antiillegal.check.checks;
 
 import me.txmc.core.antiillegal.check.Check;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
 
-/** Placeholder for DurabilityCheck */
+/**
+ * Caps item damage to the maximum allowed by the material.
+ */
 public class DurabilityCheck implements Check {
     @Override
-    public boolean check(ItemStack item) { return false; }
+    public boolean check(ItemStack item) {
+        if (!(item.getItemMeta() instanceof Damageable meta)) return false;
+        int max = item.getType().getMaxDurability();
+        return meta.getDamage() > max;
+    }
+
     @Override
-    public boolean shouldCheck(ItemStack item) { return false; }
+    public boolean shouldCheck(ItemStack item) {
+        return item != null && item.getType().getMaxDurability() > 0 && item.getItemMeta() instanceof Damageable;
+    }
+
     @Override
-    public void fix(ItemStack item) {}
+    public void fix(ItemStack item) {
+        ItemMeta im = item.getItemMeta();
+        if (!(im instanceof Damageable meta)) return;
+        int max = item.getType().getMaxDurability();
+        if (meta.getDamage() > max) meta.setDamage(max);
+        item.setItemMeta(im);
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/EnchantCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/EnchantCheck.java
@@ -1,14 +1,35 @@
 package me.txmc.core.antiillegal.check.checks;
 
 import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 
-/** Placeholder for EnchantCheck */
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Limits enchantments to their maximum allowed levels.
+ */
 public class EnchantCheck implements Check {
     @Override
-    public boolean check(ItemStack item) { return false; }
+    public boolean check(ItemStack item) {
+        for (Map.Entry<Enchantment, Integer> e : item.getEnchantments().entrySet()) {
+            if (e.getValue() > e.getKey().getMaxLevel()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
-    public boolean shouldCheck(ItemStack item) { return false; }
+    public boolean shouldCheck(ItemStack item) {
+        return item != null && !item.getEnchantments().isEmpty();
+    }
+
     @Override
-    public void fix(ItemStack item) {}
+    public void fix(ItemStack item) {
+        Map<Enchantment, Integer> enchants = new HashMap<>(item.getEnchantments());
+        enchants.forEach(item::removeEnchantment);
+        enchants.forEach((ench, lvl) -> item.addEnchantment(ench, Math.min(lvl, ench.getMaxLevel())));
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalDataCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalDataCheck.java
@@ -1,7 +1,9 @@
 package me.txmc.core.antiillegal.check.checks;
 
 import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * Check for illegal NBT data on items.
@@ -12,16 +14,22 @@ import org.bukkit.inventory.ItemStack;
 public class IllegalDataCheck implements Check {
     @Override
     public boolean check(ItemStack item) {
-        return false;
+        ItemMeta meta = item.getItemMeta();
+        return meta != null && !meta.getPersistentDataContainer().isEmpty();
     }
 
     @Override
     public boolean shouldCheck(ItemStack item) {
-        return false;
+        return item != null && item.hasItemMeta();
     }
 
     @Override
     public void fix(ItemStack item) {
-        // no-op
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        for (NamespacedKey key : meta.getPersistentDataContainer().getKeys()) {
+            meta.getPersistentDataContainer().remove(key);
+        }
+        item.setItemMeta(meta);
     }
 }

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/NameCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/NameCheck.java
@@ -3,14 +3,35 @@ package me.txmc.core.antiillegal.check.checks;
 import me.txmc.core.antiillegal.check.Check;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
-/** Placeholder for NameCheck */
+/**
+ * Simple display name length limiter.
+ */
 public class NameCheck implements Check {
-    public NameCheck(ConfigurationSection section) {}
+    private final int maxLength;
+
+    public NameCheck(ConfigurationSection section) {
+        this.maxLength = section != null ? section.getInt("AntiIllegal.MaxNameLength", 40) : 40;
+    }
+
     @Override
-    public boolean check(ItemStack item) { return false; }
+    public boolean check(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        return meta != null && meta.hasDisplayName() && meta.getDisplayName().length() > maxLength;
+    }
+
     @Override
-    public boolean shouldCheck(ItemStack item) { return false; }
+    public boolean shouldCheck(ItemStack item) {
+        return item != null && item.hasItemMeta();
+    }
+
     @Override
-    public void fix(ItemStack item) {}
+    public void fix(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null && meta.hasDisplayName() && meta.getDisplayName().length() > maxLength) {
+            meta.setDisplayName(meta.getDisplayName().substring(0, maxLength));
+            item.setItemMeta(meta);
+        }
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/OverStackCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/OverStackCheck.java
@@ -3,12 +3,22 @@ package me.txmc.core.antiillegal.check.checks;
 import me.txmc.core.antiillegal.check.Check;
 import org.bukkit.inventory.ItemStack;
 
-/** Placeholder for OverStackCheck */
+/**
+ * Ensures stacks do not exceed their maximum size.
+ */
 public class OverStackCheck implements Check {
     @Override
-    public boolean check(ItemStack item) { return false; }
+    public boolean check(ItemStack item) {
+        return item.getAmount() > item.getMaxStackSize();
+    }
+
     @Override
-    public boolean shouldCheck(ItemStack item) { return false; }
+    public boolean shouldCheck(ItemStack item) {
+        return item != null && item.getMaxStackSize() > 0;
+    }
+
     @Override
-    public void fix(ItemStack item) {}
+    public void fix(ItemStack item) {
+        item.setAmount(item.getMaxStackSize());
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/PotionCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/PotionCheck.java
@@ -2,13 +2,42 @@ package me.txmc.core.antiillegal.check.checks;
 
 import me.txmc.core.antiillegal.check.Check;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.PotionEffect;
 
-/** Placeholder for PotionCheck */
+import java.util.ArrayList;
+
+/**
+ * Removes excessively strong custom potion effects.
+ */
 public class PotionCheck implements Check {
+    private static final int MAX_AMPLIFIER = 10;
+    private static final int MAX_DURATION = 20 * 60 * 8; // 8 minutes
+
     @Override
-    public boolean check(ItemStack item) { return false; }
+    public boolean check(ItemStack item) {
+        if (!(item.getItemMeta() instanceof PotionMeta meta)) return false;
+        for (PotionEffect effect : meta.getCustomEffects()) {
+            if (effect.getAmplifier() > MAX_AMPLIFIER || effect.getDuration() > MAX_DURATION) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
-    public boolean shouldCheck(ItemStack item) { return false; }
+    public boolean shouldCheck(ItemStack item) {
+        return item != null && item.getItemMeta() instanceof PotionMeta;
+    }
+
     @Override
-    public void fix(ItemStack item) {}
+    public void fix(ItemStack item) {
+        if (!(item.getItemMeta() instanceof PotionMeta meta)) return;
+        for (PotionEffect effect : new ArrayList<>(meta.getCustomEffects())) {
+            if (effect.getAmplifier() > MAX_AMPLIFIER || effect.getDuration() > MAX_DURATION) {
+                meta.removeCustomEffect(effect.getType());
+            }
+        }
+        item.setItemMeta(meta);
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/listeners/IllegalBlocksCleaner.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/IllegalBlocksCleaner.java
@@ -58,7 +58,7 @@ public class IllegalBlocksCleaner implements Listener {
                             type == Material.BARRIER ||
                             type == Material.LIGHT ||
                             type == Material.END_PORTAL ||
-                            (type == Material.BEDROCK && y >= yLowerLimit + 5))) {
+                            (type == Material.BEDROCK && y > -50))) {
                         block.setType(Material.AIR);
                     }
 

--- a/src/main/java/me/txmc/core/antiillegal/listeners/InventoryListeners.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/InventoryListeners.java
@@ -1,9 +1,26 @@
 package me.txmc.core.antiillegal.listeners;
 
 import me.txmc.core.antiillegal.AntiIllegalMain;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
 
-/** Placeholder for InventoryListeners */
+/**
+ * Checks items that move through inventories.
+ */
 public class InventoryListeners implements Listener {
-    public InventoryListeners(AntiIllegalMain main) {}
+    private final AntiIllegalMain main;
+
+    public InventoryListeners(AntiIllegalMain main) {
+        this.main = main;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onInventoryClick(InventoryClickEvent event) {
+        ItemStack item = event.getCurrentItem();
+        if (item != null) {
+            main.checkFixItem(item, event);
+        }
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/listeners/MiscListeners.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/MiscListeners.java
@@ -1,9 +1,24 @@
 package me.txmc.core.antiillegal.listeners;
 
 import me.txmc.core.antiillegal.AntiIllegalMain;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ItemSpawnEvent;
+import org.bukkit.inventory.ItemStack;
 
-/** Placeholder for MiscListeners */
+/**
+ * Handles miscellaneous item checks.
+ */
 public class MiscListeners implements Listener {
-    public MiscListeners(AntiIllegalMain main) {}
+    private final AntiIllegalMain main;
+
+    public MiscListeners(AntiIllegalMain main) {
+        this.main = main;
+    }
+
+    @EventHandler
+    public void onItemSpawn(ItemSpawnEvent event) {
+        ItemStack item = event.getEntity().getItemStack();
+        main.checkFixItem(item, null);
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/listeners/PlayerListeners.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/PlayerListeners.java
@@ -1,9 +1,27 @@
 package me.txmc.core.antiillegal.listeners;
 
 import me.txmc.core.antiillegal.AntiIllegalMain;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.ItemStack;
 
-/** Placeholder for PlayerListeners */
+/**
+ * Scans player inventories on join.
+ */
 public class PlayerListeners implements Listener {
-    public PlayerListeners(AntiIllegalMain main) {}
+    private final AntiIllegalMain main;
+
+    public PlayerListeners(AntiIllegalMain main) {
+        this.main = main;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        for (ItemStack item : event.getPlayer().getInventory().getContents()) {
+            if (item != null) {
+                main.checkFixItem(item, null);
+            }
+        }
+    }
 }

--- a/src/main/java/me/txmc/core/antiillegal/listeners/StackedTotemsListener.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/StackedTotemsListener.java
@@ -1,6 +1,26 @@
 package me.txmc.core.antiillegal.listeners;
 
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityResurrectEvent;
+import org.bukkit.inventory.ItemStack;
 
-/** Placeholder for StackedTotemsListener */
-public class StackedTotemsListener implements Listener {}
+/**
+ * Prevents stacked totems from bypassing normal limits.
+ */
+public class StackedTotemsListener implements Listener {
+    @EventHandler
+    public void onResurrect(EntityResurrectEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        ItemStack main = player.getInventory().getItemInMainHand();
+        if (main.getType() == Material.TOTEM_OF_UNDYING && main.getAmount() > 1) {
+            main.setAmount(1);
+        }
+        ItemStack off = player.getInventory().getItemInOffHand();
+        if (off.getType() == Material.TOTEM_OF_UNDYING && off.getAmount() > 1) {
+            off.setAmount(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- protect login spawn area and block bedrock/barrier placement
- clean overworld bedrock above -50 on chunk load
- implement missing anti-illegal checks
- implement listeners for anti-illegal system

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a16552e18832ab20db594058b1a46